### PR TITLE
Feature/#6 지점 이미지 추가

### DIFF
--- a/src/main/java/com/onz/bars/bar/component/parser/OpenHourParser.java
+++ b/src/main/java/com/onz/bars/bar/component/parser/OpenHourParser.java
@@ -70,6 +70,6 @@ public class OpenHourParser {
         if (hourMatcher.find()) {
             return new String[]{hourMatcher.group(1),hourMatcher.group(2)};
         }
-        return null;
+        return new String[]{"00:00", "00:00"};
     }
 }

--- a/src/main/java/com/onz/bars/bar/component/scraper/KakaoMapBarImageMapper.java
+++ b/src/main/java/com/onz/bars/bar/component/scraper/KakaoMapBarImageMapper.java
@@ -1,0 +1,30 @@
+package com.onz.bars.bar.component.scraper;
+
+import com.onz.bars.bar.domain.Bar;
+import com.onz.bars.bar.domain.barImage.BarImage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KakaoMapBarImageMapper {
+
+    public List<BarImage> scrapeBarImageData(Bar bar, List<String> barImageItems) {
+        List<BarImage> results = new ArrayList<>();
+
+        if (barImageItems.isEmpty()) {
+            return results;
+        }
+
+        for (String item : barImageItems) {
+            results.add(new BarImage(bar, item));
+        }
+
+        return results;
+    }
+}

--- a/src/main/java/com/onz/bars/bar/component/scraper/KakaoMapScraper.java
+++ b/src/main/java/com/onz/bars/bar/component/scraper/KakaoMapScraper.java
@@ -14,6 +14,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 
 @Slf4j
@@ -27,7 +28,10 @@ public class KakaoMapScraper {
 
     private final String MENU_ELEMENT_NAME = ".list_menu li";
     private final String OPERATION_ELEMENT_NAME = ".list_operation .txt_operation";
-    private final String RATING_ELEMENT_NAME = ".evaluation_review .num_rate";
+    private final String RATING_ELEMENT_NAME = ".grade_star .num_rate";
+    private final String IMAGE_ELEMENT_SELECTOR = ".list_photo .link_photo";
+    private final String FULL_IMAGE_SELECTOR = ".view_image .img_photo";
+    private final String FULL_IMAGE_CLOSE_BUTTON_SELECTOR = ".ico_comm.link_close";
 
     @PostConstruct
     public void init() {
@@ -45,17 +49,59 @@ public class KakaoMapScraper {
                 ExpectedConditions.presenceOfElementLocated(By.cssSelector(RATING_ELEMENT_NAME))
         ));
 
-        // 메뉴가 2페이지 이상인 경우
-        List<WebElement> moreMenuButtons = webDriver.findElements(By.cssSelector("a.link_more"));
-        if (!moreMenuButtons.isEmpty() && moreMenuButtons.getFirst().isDisplayed()) {
-            moreMenuButtons.getFirst().click();
-            Thread.sleep(500);
+        List<WebElement> wholeMenu = webDriver.findElements(By.cssSelector(".list_menu"));
+
+        if (!wholeMenu.isEmpty()) {
+            int maxPage = Integer.parseInt(wholeMenu.getFirst().getAttribute("data-maxpage"));
+            log.warn("maxPage=" + maxPage);
+
+            for (int i = 1; i < maxPage; i++) {
+                clickMoreMenuButton();
+            }
         }
 
         List<WebElement> menuItems = webDriver.findElements(By.cssSelector(MENU_ELEMENT_NAME));
         List<WebElement> openDayItems = webDriver.findElements(By.cssSelector(OPERATION_ELEMENT_NAME));
         List<WebElement> ratingItems = webDriver.findElements(By.cssSelector(RATING_ELEMENT_NAME));
+        List<WebElement> barImages = webDriver.findElements(By.cssSelector(IMAGE_ELEMENT_SELECTOR));
 
-        return new KakaoMapScrapeResponse(menuItems, openDayItems, ratingItems);
+        List<String> barImageItems = scrapeFullImageItemsFromThumbnail(barImages);
+
+        return new KakaoMapScrapeResponse(menuItems, openDayItems, ratingItems, barImageItems);
+    }
+
+    private void clickMoreMenuButton() throws InterruptedException {
+        WebDriverWait wait = new WebDriverWait(webDriver, Duration.ofSeconds(1));
+
+        WebElement moreMenuButton = wait.until(ExpectedConditions.elementToBeClickable(
+                By.cssSelector("a.link_more[data-logevent='additional_info,menu,more_menu']")));
+
+        if (moreMenuButton.isDisplayed()) {
+            moreMenuButton.click();
+            Thread.sleep(500);
+        }
+    }
+
+    private List<String> scrapeFullImageItemsFromThumbnail(List<WebElement> barImageItems) {
+        List<String> results = new ArrayList<>();
+        WebDriverWait wait = new WebDriverWait(webDriver, Duration.ofSeconds(2));
+
+        if (barImageItems.isEmpty()) {
+            return results;
+        }
+
+        for (WebElement image : barImageItems) {
+            image.click();
+
+            wait.until(ExpectedConditions.presenceOfElementLocated(By.id("photoViewer")));
+            WebElement fullImage = wait.until(ExpectedConditions.visibilityOfElementLocated(By.cssSelector(FULL_IMAGE_SELECTOR)));
+
+            results.add(fullImage.getAttribute("src"));
+
+            WebElement closeButton = wait.until(ExpectedConditions.elementToBeClickable(By.cssSelector(FULL_IMAGE_CLOSE_BUTTON_SELECTOR)));
+            closeButton.click();
+        }
+
+        return results;
     }
 }

--- a/src/main/java/com/onz/bars/bar/domain/barImage/BarImage.java
+++ b/src/main/java/com/onz/bars/bar/domain/barImage/BarImage.java
@@ -1,0 +1,24 @@
+package com.onz.bars.bar.domain.barImage;
+
+import com.onz.bars.bar.domain.Bar;
+import com.onz.bars.common.domain.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BarImage extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "bar_id")
+    private Bar bar;
+
+    private String imageUrl;
+}

--- a/src/main/java/com/onz/bars/bar/model/response/scrapeResponse/KakaoMapScrapeResponse.java
+++ b/src/main/java/com/onz/bars/bar/model/response/scrapeResponse/KakaoMapScrapeResponse.java
@@ -13,4 +13,5 @@ public class KakaoMapScrapeResponse {
     private List<WebElement> menuItems;
     private List<WebElement> openDays;
     private List<WebElement> ratingItems;
+    private List<String> barImageItems;
 }

--- a/src/main/java/com/onz/bars/bar/repository/BarImageRepository.java
+++ b/src/main/java/com/onz/bars/bar/repository/BarImageRepository.java
@@ -1,0 +1,7 @@
+package com.onz.bars.bar.repository;
+
+import com.onz.bars.bar.domain.barImage.BarImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BarImageRepository extends JpaRepository<BarImage, Long> {
+}

--- a/src/main/java/com/onz/bars/bar/service/KakaoLocalApiService.java
+++ b/src/main/java/com/onz/bars/bar/service/KakaoLocalApiService.java
@@ -1,14 +1,16 @@
 package com.onz.bars.bar.service;
 
 import com.onz.bars.bar.component.apiCaller.KakaoLocalApiCaller;
+import com.onz.bars.bar.component.resolver.KeywordRegionResolver;
+import com.onz.bars.bar.component.scraper.KakaoMapBarImageMapper;
 import com.onz.bars.bar.domain.Bar;
+import com.onz.bars.bar.domain.barImage.BarImage;
+import com.onz.bars.bar.domain.region.Region;
 import com.onz.bars.bar.model.response.kakaoLocal.KakaoMapApiResponse;
 import com.onz.bars.bar.model.response.kakaoLocal.Place;
 import com.onz.bars.bar.domain.menu.Menu;
 import com.onz.bars.bar.domain.openHour.OpenHour;
-import com.onz.bars.bar.repository.BarRepository;
-import com.onz.bars.bar.repository.MenuRepository;
-import com.onz.bars.bar.repository.OpenHourReposistory;
+import com.onz.bars.bar.repository.*;
 import com.onz.bars.bar.component.scraper.KakaoMapMenuMapper;
 import com.onz.bars.bar.component.scraper.KakaoMapOpenHourMapper;
 import com.onz.bars.bar.component.scraper.KakaoMapScraper;
@@ -30,17 +32,22 @@ public class KakaoLocalApiService {
 
     private final KakaoMapMenuMapper menuMapper;
     private final KakaoMapOpenHourMapper openHourMapper;
+    private final KakaoMapBarImageMapper barImageMapper;
 
     private final BarRepository barRepository;
+    private final KeywordRegionResolver regionResolver;
     private final MenuRepository menuRepository;
     private final OpenHourReposistory openHourReposistory;
+    private final BarImageRepository barImageRepository;
 
     public void saveBarAndMenuAndOpenHour(String keyword, int page) throws IOException, InterruptedException {
         KakaoMapApiResponse response = apiCaller.getResponseFromApi(keyword, page);
         List<Place> documents = response.getDocuments();
 
+        Region region = regionResolver.getRegionFromKeyword(keyword);
+
         for (Place place:documents) {
-            Bar bar = barRepository.save(Bar.of(place));
+            Bar bar = barRepository.save(Bar.of(place, region));
 
             KakaoMapScrapeResponse scrapeResponse = scraper.getItemsFromUrl(bar.getUrl());
 
@@ -53,6 +60,11 @@ public class KakaoLocalApiService {
                     bar, scrapeResponse.getOpenDays());
             for (OpenHour openHour : openHours) {
                 openHourReposistory.save(openHour);
+            }
+
+            List<BarImage> barImages = barImageMapper.scrapeBarImageData(bar, scrapeResponse.getBarImageItems());
+            for (BarImage image : barImages) {
+                barImageRepository.save(image);
             }
         }
     }


### PR DESCRIPTION
## 요약
- 지점 이미지 엔티티 `BarImage` 추가
- 지점 정보 스크래핑 시 지점 이미지도 함께 수집하도록 수정
- (영업시간) 정보가 `null`일 시 `"00:00"`로 처리하도록 수정

## 관련이슈
#6 

## 유의사항

## 해결되지 않은 문제
- 카카오맵 상세정보 페이지에 나오는 5장을 기준으로 하였으나, 마지막 5번째 사진과 1번째 사진이 동일함